### PR TITLE
Added Support for SPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AckAck
-AckAck is a python script that automatically generates a plist based on the licenses in your Carthage or CocoaPods folder. When you use the plists in your app, the licenses will show up in the Settings app.
+AckAck is a python script that automatically generates a plist based on the licenses in your Carthage, CocoaPods, or SwiftPackageManager folder. When you use the plists in your app, the licenses will show up in the Settings app.
 
 ![Settings example](http://i.imgur.com/V4JfPlC.png)
 
@@ -45,3 +45,26 @@ You can see the options and other help information by running `./ackack.py --hel
 cd $SRCROOT
 ./ackack.py
 ```
+
+### Using with Swift Package Manager
+Things get a little trickier when using SPM because of how Xcode stores the packages. If you plan to integrate with Xcode, set your Run Script Build Phase like so:
+
+```sh
+DERIVED_DATA_CANDIDATE="${BUILD_ROOT}"
+while ! [ -d "${DERIVED_DATA_CANDIDATE}/SourcePackages/checkouts" ]; do
+  if [ "${DERIVED_DATA_CANDIDATE}" = / ]; then
+    echo >&2 "error: Unable to locate SourcePackages directory from BUILD_ROOT: '${BUILD_ROOT}'"
+    exit 1
+  fi
+
+  DERIVED_DATA_CANDIDATE="$(dirname "${DERIVED_DATA_CANDIDATE}")"
+done
+
+
+cd $SRCROOT
+./ackack.py --spminput ${DERIVED_DATA_CANDIDATE}
+```
+
+Otherwise, you'll need to specify the `--spminput` argument when running AckAck. SPM contents (unless you've specified otherwise) are located in your app's derived data folder under `/SourcePackages/checkouts`. The path to that folder usually looks something like this:
+
+    /Users/username/Library/Developer/Xcode/DerivedData/AppName-buildUUID/SourcePackages/checkouts

--- a/ackack.py
+++ b/ackack.py
@@ -10,7 +10,7 @@ import sys
 from argparse import ArgumentParser
 
 
-VERSION = '4.1'
+VERSION = '4.2'
 
 
 # Configure the logger
@@ -41,7 +41,9 @@ class Generator:
             input_folders.append(carthage_folder)
         if cocoapods_folder:
             input_folders.append(cocoapods_folder)
-
+        if self.options.spm_folder:
+            input_folders.append(self.options.spm_folder)
+        
         self.options.input_folders = input_folders
 
     def find_output_folder(self):
@@ -249,6 +251,11 @@ def main():
     parser.add_argument(
         '-i', '--input', dest='input_folders', nargs='*',
         help='the path to the input folder(s), e.g. Carthage/Checkouts'
+    )
+
+    parser.add_argument(
+        '-s', '--spminput', dest='spm_folder',
+        help="the path to the app's derived data folder pointing to source packages and checkouts, eg. ${DERIVED_DATA_CANDIDATE}/SourcePackages/checkouts/"
     )
 
     parser.add_argument(


### PR DESCRIPTION
As adoption of Swift Package Manager expands across the iOS community, it would be mighty nice to have support for SPM Acknowledgments generation using this tool.

My solution is a little wonky as far as Xcode integration goes... but considering the way in which the packages are stored (in a dynamically named Derived Data folder upon build), I'm not sure what else could be done.